### PR TITLE
gpt3.5 eval preference dataset

### DIFF
--- a/eval/oai2_pref_dataset.py
+++ b/eval/oai2_pref_dataset.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import tyro
+from datasets import load_dataset
+from oai2 import ArgsWrapper, llm_judge
+
+if __name__ == "__main__":
+    all_args = tyro.cli(ArgsWrapper)
+    args = all_args.args
+    ljc = all_args.ljc
+
+    dataset = load_dataset(
+        "vwxyzjn/summarize_from_feedback_oai_preprocessing_1706381144", split="train"
+    )
+
+    dataset = dataset.select_columns(["query", "chosen", "rejected"])
+
+    df = pd.DataFrame(dataset)
+
+    df["chosen"] = df["chosen"].map(lambda x: x.split("<|endoftext|>")[0].strip())
+    df["rejected"] = df["rejected"].map(lambda x: x.split("<|endoftext|>")[0].strip())
+    df["prompt"] = df["query"].map(lambda x: x.strip())
+    df["response0"] = df["chosen"].map(lambda x: x.strip())
+    df["response1"] = df["rejected"].map(lambda x: x.strip())
+    judge_df = llm_judge(ljc, df)
+    judge_df.to_csv(args.output_path)


### PR DESCRIPTION
evaluate the tldr preference dataset using gpt3.5 to find out the agreement between gpt-3.5 and the dataset. 

this could be useful to evaluate how effective GPT-3.5 is as an external evaluator for models trained on TLDR. Agreement will likely not be 100%, but if it is comparable to other human-human annotator agreement, then LLM-as-a-judge would be a good metric here. 

a couple notes:
- I am evaluating the train set, not the validation set
- args.n is currently set to `64`, but ideally would be the whole dataset
- the prompt contains the ending `TLDR:`, not sure if this should be removed or is what you used for other evals